### PR TITLE
Remove DIRTY NIF flag

### DIFF
--- a/c_src/zstd_nif.c
+++ b/c_src/zstd_nif.c
@@ -405,8 +405,8 @@ static int zstd_on_upgrade(ErlNifEnv *env, void **priv, void **old, ERL_NIF_TERM
 }
 
 static ErlNifFunc nif_funcs[] = {
-  { "compress"                    , 2, zstd_nif_compress                   , ERL_DIRTY_JOB_CPU_BOUND },
-  { "decompress"                  , 1, zstd_nif_decompress                 , ERL_DIRTY_JOB_CPU_BOUND },
+  { "compress"                    , 2, zstd_nif_compress                                             },
+  { "decompress"                  , 1, zstd_nif_decompress                                           },
 
   { "new_compression_stream"      , 0, zstd_nif_new_compression_stream                               },
   { "new_decompression_stream"    , 0, zstd_nif_new_decompression_stream                             },


### PR DESCRIPTION
Thank-you for providing this repo, I've been able to use it to test adding zstd compression to the leveled database (which is used as a storage backend for the Riak database).  After running some experiments adding this zstd compression library, it has been observed that there appears to be a significant cost from the recent PR which set the `ERL_DIRTY_JOB_CPU_BOUND` on the compress and decompress NIF.

See https://github.com/nhs-riak/zstd-erlang/issues/1.  In the [leveled perf_SUITE ct test](https://github.com/martinsumner/leveled/blob/mas-d31-pr427i416/test/end_to_end/perf_SUITE.erl) (which is broad database load test), there is a 10%-30% cost from running ZSTD with the flag.  Even with [a simple unit test](https://github.com/martinsumner/leveled/blob/mas-d31-pr427i416/src/leveled_codec.erl#L925-L987) there is a clear difference.

With `ERL_DIRTY_JOB_CPU_BOUND`:

```Compression time ZLIB 1739 LZ4 476 ZSTD 306 Decompression time ZLIB 272 LZ4 88 ZSTD 140```

Without `ERL_DIRTY_JOB_CPU_BOUND`:

```Compression time ZLIB 1877 LZ4 456 ZSTD 251 Decompression time ZLIB 284 LZ4 86 ZSTD 110```

Reading the nif guidelines, it talks of the threshold being 1ms before a dirty CPU flag is required.  Given the overhead is the flag appropriate for standard compress/decompress function?  Perhaps there should be a separate entry point if one is sure the compress/decompress time is within those bounds?

I have limited experience with NIFs, so this PR is provided as a suggestion, but I'm happy to accept that this might not be the right thing to do.
